### PR TITLE
Update background gradient color from blue to stone

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="bg-black min-h-screen overflow-hidden">
-        <div className="bg-gradient-to-b from-blue-950 to-black min-h-screen">
+        <div className="bg-gradient-to-b from-stone-850 to-black min-h-screen">
           {children}
         </div>
       </body>


### PR DESCRIPTION
This PR changes the background gradient in the root layout from blue-950 to stone-850, providing a warmer tonal appearance that better aligns with the brand's visual identity. The change is minimal and isolated to the root layout component.